### PR TITLE
[Fix] make HylaFAX build for gcc>=10

### DIFF
--- a/libhylafax/FaxClient.c++
+++ b/libhylafax/FaxClient.c++
@@ -116,7 +116,7 @@ FaxClient::printWarning(const char* fmt ...)
 void
 FaxClient::vprintWarning(const char* fmt, va_list ap)
 {
-    fprintf(stderr, NLS::TEXT("Warning, "));
+    fprintf(stderr, "%s", NLS::TEXT("Warning, "));
     vfprintf(stderr, fmt, ap);
     fputs("\n", stderr);
 }

--- a/libhylafax/SNPPClient.c++
+++ b/libhylafax/SNPPClient.c++
@@ -103,7 +103,7 @@ SNPPClient::printWarning(const char* fmt ...)
 void
 SNPPClient::vprintWarning(const char* fmt, va_list ap)
 {
-    fprintf(stderr, NLS::TEXT("Warning, "));
+    fprintf(stderr, "%s", NLS::TEXT("Warning, "));
     vfprintf(stderr, fmt, ap);
     fputs("\n", stderr);
 }

--- a/libhylafax/TextFormat.c++
+++ b/libhylafax/TextFormat.c++
@@ -1371,7 +1371,7 @@ TextFont::openAFMFile(fxStr& fontpath)
 {
     fxStr emsg;
     if (!decodeFontName(family, fontpath, emsg)) {
-	fprintf(stderr,emsg);
+	fprintf(stderr, "%s", emsg);
 	return NULL;
     }
     return Sys::fopen(fontpath, "r");

--- a/libhylafax/TypeRules.c++
+++ b/libhylafax/TypeRules.c++
@@ -101,7 +101,7 @@ TypeRule::match(const void* data, size_t size, bool verbose) const
 	    printf(" \"%s\"", value.s);
 	else if (type != ASCII && type != ASCIIESC) {
 	    if (op == ANY)
-		printf(NLS::TEXT(" <any value>"));
+		printf("%s", NLS::TEXT(" <any value>"));
 	    else
 		printf(" %#llx", (long long) value.v);
 	}
@@ -109,7 +109,7 @@ TypeRule::match(const void* data, size_t size, bool verbose) const
     }
     if (off > (off_t)size) {
 	if (verbose)
-	    printf(NLS::TEXT("failed (offset past data)\n"));
+	    printf("%s", NLS::TEXT("failed (offset past data)\n"));
 	return (false);
     }
     bool ok = false;
@@ -162,7 +162,7 @@ TypeRule::match(const void* data, size_t size, bool verbose) const
 	    break;
 	}
 	if (verbose)
-	    printf(NLS::TEXT("failed (insufficient data)\n"));
+	    printf("%s", NLS::TEXT("failed (insufficient data)\n"));
 	return (false);
     case LONG:
 	if (off + 4 < (off_t)size) {
@@ -171,7 +171,7 @@ TypeRule::match(const void* data, size_t size, bool verbose) const
 	    break;
 	}
 	if (verbose)
-	    printf(NLS::TEXT("failed (insufficient data)\n"));
+	    printf("%s", NLS::TEXT("failed (insufficient data)\n"));
 	return (false);
     }
     /*
@@ -195,7 +195,7 @@ done:
 	    printf(NLS::TEXT("success (result %s, rule \"%s\")\n"),
 		resultNames[result], (const char*) cmd);
 	else
-	    printf(NLS::TEXT("failed (comparison)\n"));
+	    printf("%s", NLS::TEXT("failed (comparison)\n"));
     }
     return (ok);
 }
@@ -496,6 +496,6 @@ TypeRules::match(const void* data, u_int size) const
 	    return (&(*rules)[i + match2(i, data, size, verbose)]);
     }
     if (verbose)
-	printf(NLS::TEXT("no match\n"));
+	printf("%s", NLS::TEXT("no match\n"));
     return (NULL);
 }


### PR DESCRIPTION
Since gcc>=10 enables `-Werror-format-security` by default, it does not allow `printf(str)` now.